### PR TITLE
Add support for registering temporary stores

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: objective-c
 rvm: 2.2.2
 osx_image: xcode7.3
 before_install: gem update bundler
-install: travis_wait bundle install
+install: bundle install
 before_script: cd Example && pod install 
-script: xctool -workspace FLUX.xcworkspace -scheme FLUX-Example build test -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+script: travis_wait 30 xctool -workspace FLUX.xcworkspace -scheme FLUX-Example build test -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ osx_image: xcode7.3
 before_install: gem update bundler
 install: bundle install
 before_script: cd Example && pod install 
-script: travis_wait 30 xctool -workspace FLUX.xcworkspace -scheme FLUX-Example build test -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+script: xcodebuild -workspace FLUX.xcworkspace -scheme FLUX-Example build test -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: objective-c
 rvm: 2.2.2
+osx_image: xcode7.3
 before_install: gem update bundler
 install: travis_wait bundle install
 before_script: cd Example && pod install 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
 rvm: 2.2.2
 before_install: gem update bundler
-install: bundle install
+install: travis_wait bundle install
 before_script: cd Example && pod install 
 script: xctool -workspace FLUX.xcworkspace -scheme FLUX-Example build test -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ osx_image: xcode7.3
 before_install: gem update bundler
 install: bundle install
 before_script: cd Example && pod install 
-script: xcodebuild -workspace FLUX.xcworkspace -scheme FLUX-Example build test -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
+script: xcodebuild -workspace FLUX.xcworkspace -scheme FLUX-Example test -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | grep error

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - FLUX (0.1.1):
+  - FLUX (0.2.0):
     - KVOController
     - libextobjc
   - Kiwi (2.4.0)
-  - KVOController (1.0.3)
+  - KVOController (1.1.0)
   - libextobjc (0.4.1):
     - libextobjc/EXTADT (= 0.4.1)
     - libextobjc/EXTConcreteProtocol (= 0.4.1)
@@ -49,9 +49,9 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  FLUX: 261aa2a9820ed0bc14eda8e3b268af6af542b340
+  FLUX: a7a0c909baa6c5c926c9bce3d8846b2c4d71e8f8
   Kiwi: f49c9d54b28917df5928fe44968a39ed198cb8a8
-  KVOController: 9fd8f0343670994e4b6f9f0b31f5a45663f3e1cf
+  KVOController: 321b5fc59300fcaabd42c0f679baa7a27efbb2fd
   libextobjc: a650fc1bf489a3d3a9bc2e621efa3e1006fc5471
 
 COCOAPODS: 0.39.0

--- a/Example/Tests/Domain/Dispatchers/TEActionsDispatcherSpec.m
+++ b/Example/Tests/Domain/Dispatchers/TEActionsDispatcherSpec.m
@@ -62,9 +62,25 @@ describe(@"dispatchAction", ^{
         
         for(NSInteger i = 0; i < 10; i++) {
             id subdispatcher = [KWMock mockForProtocol:@protocol(TEDispatcherProtocol)];
+            [subdispatcher stub:@selector(store) andReturn:[TEBaseStore mock]];
+            
             [[subdispatcher should] receive:@selector(dispatchAction:) withArguments:actionMock];
             [dispatchers addObject:subdispatcher];
         }
+        sut.subDispatchers = dispatchers;
+        
+        [sut dispatchAction:actionMock];
+    });
+    it(@"should not dispatch action to subdispatchers that stores have beed released", ^{
+        
+        id actionMock = [KWMock mockForClass:[TEBaseAction class]];
+        
+        id subdispatcher = [KWMock mockForProtocol:@protocol(TEDispatcherProtocol)];
+        [subdispatcher stub:@selector(store)];
+        
+        [[subdispatcher shouldNot] receive:@selector(dispatchAction:) withArguments:actionMock];
+        
+        NSMutableArray *dispatchers = [@[subdispatcher] mutableCopy];
         sut.subDispatchers = dispatchers;
         
         [sut dispatchAction:actionMock];

--- a/Pod/Classes/Dispatcher/TEActionsDispatcher.m
+++ b/Pod/Classes/Dispatcher/TEActionsDispatcher.m
@@ -19,6 +19,8 @@
 
 @implementation TEActionsDispatcher
 
+@synthesize store = _store;
+
 - (instancetype)init
 {
     self = [super init];
@@ -37,10 +39,17 @@
 
 - (void)dispatchAction:(TEBaseAction *)action
 {
+    NSMutableArray *dispatchersToRemove = [NSMutableArray array];
     for(id<TEDispatcherProtocol> dispatcher in self.subDispatchers)
     {
-        [dispatcher dispatchAction:action];
+        if (dispatcher.store) {
+            [dispatcher dispatchAction:action];
+        }
+        else {
+            [dispatchersToRemove addObject:dispatcher];
+        }
     }
+    [self.subDispatchers removeObjectsInArray:dispatchersToRemove];
 }
 
 @end

--- a/Pod/Classes/Dispatcher/TEActionsDispatcher.m
+++ b/Pod/Classes/Dispatcher/TEActionsDispatcher.m
@@ -19,8 +19,6 @@
 
 @implementation TEActionsDispatcher
 
-@synthesize store = _store;
-
 - (instancetype)init
 {
     self = [super init];
@@ -42,12 +40,11 @@
     NSMutableArray *dispatchersToRemove = [NSMutableArray array];
     for(id<TEDispatcherProtocol> dispatcher in self.subDispatchers)
     {
-        if (dispatcher.store) {
-            [dispatcher dispatchAction:action];
-        }
-        else {
+        if (![dispatcher respondsToSelector:@selector(store)] || !dispatcher.store) {
             [dispatchersToRemove addObject:dispatcher];
+            continue;
         }
+        [dispatcher dispatchAction:action];
     }
     [self.subDispatchers removeObjectsInArray:dispatchersToRemove];
 }

--- a/Pod/Classes/Dispatcher/TEDispatcherProtocol.h
+++ b/Pod/Classes/Dispatcher/TEDispatcherProtocol.h
@@ -8,8 +8,11 @@
 
 #import <Foundation/Foundation.h>
 @class TEBaseAction;
+@class TEBaseStore;
 
 @protocol TEDispatcherProtocol <NSObject>
+
+@property (nonatomic, weak) TEBaseStore *store;
 
 - (void)dispatchAction:(TEBaseAction *)action;
 

--- a/Pod/Classes/Dispatcher/TEDispatcherProtocol.h
+++ b/Pod/Classes/Dispatcher/TEDispatcherProtocol.h
@@ -12,8 +12,9 @@
 
 @protocol TEDispatcherProtocol <NSObject>
 
-@property (nonatomic, weak) TEBaseStore *store;
-
 - (void)dispatchAction:(TEBaseAction *)action;
+
+@optional
+@property (nonatomic, weak, readonly) TEBaseStore *store;
 
 @end

--- a/Pod/Classes/Dispatcher/TEStoreDispatcher.m
+++ b/Pod/Classes/Dispatcher/TEStoreDispatcher.m
@@ -15,12 +15,11 @@
 @interface TEStoreDispatcher ()
 
 @property (nonatomic, strong) NSMutableDictionary *callbacks;
+@property (nonatomic, readwrite, weak) TEBaseStore *store;
 
 @end
 
 @implementation TEStoreDispatcher
-
-@synthesize store = _store;
 
 + (instancetype)dispatcherWithStore:(TEBaseStore *)store
 {

--- a/Pod/Classes/Dispatcher/TEStoreDispatcher.m
+++ b/Pod/Classes/Dispatcher/TEStoreDispatcher.m
@@ -15,11 +15,12 @@
 @interface TEStoreDispatcher ()
 
 @property (nonatomic, strong) NSMutableDictionary *callbacks;
-@property (nonatomic, weak) TEBaseStore * store;
 
 @end
 
 @implementation TEStoreDispatcher
+
+@synthesize store = _store;
 
 + (instancetype)dispatcherWithStore:(TEBaseStore *)store
 {

--- a/Pod/Classes/TEDomain.h
+++ b/Pod/Classes/TEDomain.h
@@ -13,6 +13,7 @@
 
 @protocol TEDomainProtocol <NSObject>
 - (TEBaseStore *)getStoreByClass:(Class)store;
+- (void)registerTemporaryStore:(TEBaseStore *)store;
 - (void)registerStore:(TEBaseStore *)store;
 - (void)dispatchAction:(TEBaseAction *)action;
 - (void)dispatchActionAndWait:(TEBaseAction *)action;

--- a/Pod/Classes/TEDomain.m
+++ b/Pod/Classes/TEDomain.m
@@ -94,6 +94,16 @@
     }];
 }
 
+- (void)registerTemporaryStore:(TEBaseStore *)store {
+    NSParameterAssert(store);
+    @weakify(self);
+    [self.executor execute:^{
+        @strongify(self);
+        [self registerStoreInDispatcher:store];
+        [self registerStoreInMiddlewares:store];
+    }];
+}
+
 - (void)registerStore:(TEBaseStore *)store {
     NSParameterAssert(store);
     NSString *storeKey = NSStringFromClass([(NSObject *)store class]);

--- a/Pod/Classes/TEDomain.m
+++ b/Pod/Classes/TEDomain.m
@@ -96,19 +96,17 @@
 
 - (void)registerTemporaryStore:(TEBaseStore *)store {
     NSParameterAssert(store);
-    @weakify(self);
-    [self.executor execute:^{
-        @strongify(self);
-        [self registerStoreInDispatcher:store];
-        [self registerStoreInMiddlewares:store];
-    }];
+    [self subscribeStoreToEvents:store];
 }
 
 - (void)registerStore:(TEBaseStore *)store {
     NSParameterAssert(store);
     NSString *storeKey = NSStringFromClass([(NSObject *)store class]);
     [self.stores setObject:store forKey:storeKey];
-    
+    [self subscribeStoreToEvents:store];
+}
+
+- (void)subscribeStoreToEvents:(TEBaseStore *)store {
     @weakify(self);
     [self.executor execute:^{
         @strongify(self);


### PR DESCRIPTION
Temporary store - store registered in dispatcher, but not stored in domain. Lifecycle is bind to specific class(viewModel, service, controller etc.)

To create temporary store you need:
1. Create store instance.
2. Make strong reference to it.
3. Register store in dispatcher through `- (void)registerTemporaryStore:(TEBaseStore *)store` method.
4. Use as common store
