### PR TITLE
Make podspec valid

### DIFF
--- a/FLUX.podspec
+++ b/FLUX.podspec
@@ -21,9 +21,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files = 'Pod/Classes/**/*'
-  s.resource_bundles = {
-    'FLUX' => ['Pod/Assets/*.png']
-  }
 
   s.prefix_header_contents = '#import <libextobjc/extobjc.h>'
 


### PR DESCRIPTION
Hey 
Your badges are broken due to invalid podspec:
```
 -> FLUX (0.2.0)
    - WARN  | description: The description is shorter than the summary.
    - ERROR | [iOS] file patterns: The `resource_bundles` pattern for `FLUX` did not match any file.
    - NOTE  | xcodebuild:  warning: no rule to process file 'FLUX/Pod/Classes/flux_models.rb' of type text.script.ruby for architecture i386
    - NOTE  | xcodebuild:  warning: no rule to process file 'FLUX/Pod/Classes/flux_models.rb' of type text.script.ruby for architecture x86_64
    - WARN  | xcodebuild:  FLUX/Pod/Classes/TEStatePersistence.m:54:37: warning: sending 'TEBaseState *__strong' to parameter of incompatible type 'id<NSCoding>'
    - NOTE  | xcodebuild:  FLUX/Pod/Classes/Stores/Protocols/TEPersistenceProtocol.h:12:34: note: passing argument to parameter 'state' here

Analyzed 1 podspec.

[!] The spec did not pass validation, due to 1 error and 2 warnings.
```
The error is fixed. Do you want me to fix warnings? Anyway, you can push it with warnings using `pod trunk push --allow-warnings`